### PR TITLE
[Feature] DOPL-675: Replaced URI by CGI method for recent Ruby versions

### DIFF
--- a/worker.rb
+++ b/worker.rb
@@ -3,7 +3,7 @@
 require 'aws-sdk'
 require 'net/http'
 require 'json'
-require 'uri'
+require 'cgi'
 require 'yaml'
 require 'syslog/logger'
 
@@ -26,7 +26,7 @@ poller.poll do |msg|
   if body.key?('Records')
     body['Records'].each do |record|
       bucket = record['s3']['bucket']['name']
-      key = URI.decode(record['s3']['object']['key']).gsub('+', ' ')
+      key = CGI.unescape(record['s3']['object']['key']).gsub('+', ' ')
       log.info "scanning s3://#{bucket}/#{key}..."
       begin
         head_response = s3.head_object(


### PR DESCRIPTION
Related to Ubuntu 24.04 migration with Ruby 3.2 (but issue also encountered on latest 2.x versions on Ubuntu 20.04)